### PR TITLE
Fix Amplify build: use Node 24

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,7 +3,7 @@ frontend:
   phases:
     preBuild:
       commands:
-        - nvm use 20
+        - nvm use 24
         - npm ci
         - npm run validate
     build:

--- a/docs/migration/amplify-deploy.md
+++ b/docs/migration/amplify-deploy.md
@@ -256,7 +256,7 @@ The old site at [http://mcpeakfamily.org](http://mcpeakfamily.org) likely pointe
 
 ### Build fails (Node version)
 
-This repo requires Node 20+. `amplify.yml` runs `nvm use 20`. In Amplify console → **Build settings**, confirm build image supports Node 20.
+This repo requires Node 22.22+ (24 recommended). `amplify.yml` runs `nvm use 24`. In Amplify console → **Build settings**, confirm build image supports Node 24.
 
 ### Build fails (Next.js 16)
 


### PR DESCRIPTION
## Summary
- Amplify main deploy failed after the notify merge because `amplify.yml` still ran `nvm use 20` while jsdom 30 requires Node 22.22+/24+.

## Test plan
- [ ] Amplify build succeeds on merge
- [ ] https://mcpeakfamily.org serves the new build


Made with [Cursor](https://cursor.com)