### PR TITLE
Add notify recipient pickers and editable email/text message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,6 @@ jobs:
 
       - name: Smoke tests (non-destructive)
         # Drop the production .next from the Build step so `next dev` starts clean.
+        # Playwright runs smoke.spec before hydration.spec and retries on CI so a
+        # cold compile of the authenticated client bundle does not flake the job.
         run: rm -rf .next && npm run test:smoke

--- a/docs/migration/messaging-notify.md
+++ b/docs/migration/messaging-notify.md
@@ -33,7 +33,7 @@ Body (optional):
 - `subject` — email only; omit to use the default template subject.
 - `text` — plain-text body for email and SMS; omit to use the default channel template. Email HTML is derived from this text.
 
-In the UI, **Notify family** includes editable subject/body fields and per-channel multi-select pickers (Select all / Clear). Defaults to everyone eligible; narrow the list for a one-person smoke test or partial blast.
+In the UI, **Email or text family** includes editable subject/body fields and per-channel multi-select pickers (Select all / Clear). Defaults to everyone eligible; narrow the list for a one-person smoke test or partial send.
 
 ## Environment
 
@@ -70,9 +70,9 @@ Local default: dry-run on (see `.env.example`).
 ## How to send (Karen / any signed-in user)
 
 1. Sign in to https://mcpeakfamily.org
-2. Open **More → Notify family**
-3. Edit subject/body if needed; confirm (or narrow) email and SMS recipients
-4. Choose **Send email blast** and/or **Send SMS blast**
+2. Open **More → Email or text family**
+3. Edit subject/body if needed; confirm (or narrow) email and text recipients
+4. Choose **Send email** and/or **Send text**
 5. Use **Copy emails** if AWS email is not configured yet
 
 ## Reputation

--- a/docs/migration/messaging-notify.md
+++ b/docs/migration/messaging-notify.md
@@ -3,8 +3,8 @@
 Signed-in users can open **More → Notify family** to:
 
 1. Copy member emails (manual send fallback)
-2. Email a fixed site-link blast via Amazon SES
-3. Text a fixed site-link blast via Amazon SNS (when enabled)
+2. Email a site-link blast via Amazon SES (editable subject + body)
+3. Text a site-link blast via Amazon SNS when enabled (editable body)
 
 The login city answer is **not** included in outbound messages.
 
@@ -17,7 +17,23 @@ The login city answer is **not** included in outbound messages.
 | `POST /api/notify/email` | Blast site link by email |
 | `POST /api/notify/sms` | Blast site link by SMS |
 
-Body (optional): `{ "dryRun": true }` — logs payloads without calling AWS (also forced when `FAMILY_MESSAGING_DRY_RUN=true`).
+Body (optional):
+
+```json
+{
+  "dryRun": true,
+  "memberIds": ["member-guid-1", "member-guid-2"],
+  "subject": "McPeak family directory",
+  "text": "You're invited to the McPeak family directory: https://mcpeakfamily.org"
+}
+```
+
+- `dryRun: true` — logs payloads without calling AWS (also forced when `FAMILY_MESSAGING_DRY_RUN=true`).
+- `memberIds` — send only to those members’ on-file email/phone. Omit to blast everyone. Empty array is rejected (`400`). Contacts are always resolved server-side from member records (client-supplied addresses are not accepted).
+- `subject` — email only; omit to use the default template subject.
+- `text` — plain-text body for email and SMS; omit to use the default channel template. Email HTML is derived from this text.
+
+In the UI, **Notify family** includes editable subject/body fields and per-channel multi-select pickers (Select all / Clear). Defaults to everyone eligible; narrow the list for a one-person smoke test or partial blast.
 
 ## Environment
 
@@ -55,7 +71,7 @@ Local default: dry-run on (see `.env.example`).
 
 1. Sign in to https://mcpeakfamily.org
 2. Open **More → Notify family**
-3. Confirm recipient counts and message preview
+3. Edit subject/body if needed; confirm (or narrow) email and SMS recipients
 4. Choose **Send email blast** and/or **Send SMS blast**
 5. Use **Copy emails** if AWS email is not configured yet
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,15 +2,19 @@ import { defineConfig, devices } from "@playwright/test";
 
 const localBaseUrl = "http://localhost:3000";
 const smokeBaseUrl = process.env.SMOKE_BASE_URL;
+const isCi = Boolean(process.env.CI);
 
 export default defineConfig({
   testDir: "./playwright",
-  timeout: 90_000,
+  // Smoke before hydration so a cold `next dev` (CI wipes .next) warms up first.
+  testMatch: ["**/smoke.spec.ts", "**/hydration.spec.ts"],
+  timeout: 120_000,
   expect: {
-    timeout: 15_000,
+    timeout: 20_000,
   },
-  // One browser at a time against the shared next dev server in CI.
-  workers: process.env.CI ? 1 : undefined,
+  // One browser at a time against the shared next server in CI.
+  workers: isCi ? 1 : undefined,
+  retries: isCi ? 2 : 0,
   reporter: [["list"]],
   use: {
     baseURL: smokeBaseUrl ?? localBaseUrl,
@@ -22,8 +26,8 @@ export default defineConfig({
         command:
           "FAMILY_USE_IN_MEMORY_DB=true FAMILY_USE_COGNITO_CREDENTIALS=false FAMILY_DDB_TABLE= FAMILY_LOGIN_ANSWER=smoke-answer npm run dev:http",
         url: localBaseUrl,
-        reuseExistingServer: !process.env.CI,
-        timeout: 120_000,
+        reuseExistingServer: !isCi,
+        timeout: 180_000,
       },
   projects: [
     {

--- a/playwright/helpers.ts
+++ b/playwright/helpers.ts
@@ -1,0 +1,51 @@
+import { expect, type Page } from "@playwright/test";
+
+const loginAnswer = process.env.PLAYWRIGHT_LOGIN_ANSWER ?? "smoke-answer";
+
+/** Log in and wait until the browse list (or survey dialog) is ready. */
+export async function loginAndRevealBrowse(page: Page): Promise<void> {
+  await page.goto("/");
+  await expect(page.getByText(/family reunion/i)).toBeVisible();
+
+  await page.getByRole("textbox").first().fill(loginAnswer);
+  await page.getByRole("button", { name: "Login" }).click();
+
+  await expect
+    .poll(async () => {
+      const response = await page.request.get("/api/auth/session");
+      if (!response.ok()) {
+        return false;
+      }
+      const body = (await response.json()) as { authenticated?: boolean };
+      return body.authenticated === true;
+    })
+    .toBe(true);
+
+  const membersResponse = await page.request.get("/api/members");
+  expect(membersResponse.status()).toBe(200);
+  const membersPayload = (await membersResponse.json()) as {
+    members: unknown[];
+  };
+  expect(membersPayload.members.length).toBeGreaterThan(0);
+
+  const browseMember = page.getByRole("button", { name: /McPeak/i }).first();
+  const surveyDialog = page.getByRole("dialog", {
+    name: /family reunion interest survey/i,
+  });
+
+  await Promise.race([
+    browseMember.waitFor({ state: "visible", timeout: 30_000 }),
+    surveyDialog.waitFor({ state: "visible", timeout: 30_000 }),
+  ]);
+
+  if (await surveyDialog.isVisible().catch(() => false)) {
+    await surveyDialog
+      .getByRole("checkbox", { name: /don't ask again/i })
+      .click();
+    await surveyDialog.getByRole("button", { name: /^close$/i }).click();
+    await expect(surveyDialog).toBeHidden();
+  }
+
+  await expect(page.locator(".MuiModal-backdrop")).toHaveCount(0);
+  await expect(browseMember).toBeVisible();
+}

--- a/playwright/helpers.ts
+++ b/playwright/helpers.ts
@@ -1,6 +1,7 @@
 import { expect, type Page } from "@playwright/test";
 
 const loginAnswer = process.env.PLAYWRIGHT_LOGIN_ANSWER ?? "smoke-answer";
+const UI_READY_TIMEOUT_MS = 60_000;
 
 /** Log in and wait until the browse list (or survey dialog) is ready. */
 export async function loginAndRevealBrowse(page: Page): Promise<void> {
@@ -21,6 +22,12 @@ export async function loginAndRevealBrowse(page: Page): Promise<void> {
     })
     .toBe(true);
 
+  // Cookie can be set before the client bundle finishes compiling on a cold
+  // `next dev` (CI deletes .next before smoke). Wait for the login chrome to go.
+  await expect(page.getByRole("button", { name: "Login" })).toBeHidden({
+    timeout: UI_READY_TIMEOUT_MS,
+  });
+
   const membersResponse = await page.request.get("/api/members");
   expect(membersResponse.status()).toBe(200);
   const membersPayload = (await membersResponse.json()) as {
@@ -34,8 +41,8 @@ export async function loginAndRevealBrowse(page: Page): Promise<void> {
   });
 
   await Promise.race([
-    browseMember.waitFor({ state: "visible", timeout: 30_000 }),
-    surveyDialog.waitFor({ state: "visible", timeout: 30_000 }),
+    browseMember.waitFor({ state: "visible", timeout: UI_READY_TIMEOUT_MS }),
+    surveyDialog.waitFor({ state: "visible", timeout: UI_READY_TIMEOUT_MS }),
   ]);
 
   if (await surveyDialog.isVisible().catch(() => false)) {

--- a/playwright/hydration.spec.ts
+++ b/playwright/hydration.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test } from "@playwright/test";
-
-const loginAnswer = process.env.PLAYWRIGHT_LOGIN_ANSWER ?? "smoke-answer";
+import { loginAndRevealBrowse } from "./helpers";
 
 test("authenticated desktop home does not hydration-mismatch", async ({
   page,
@@ -18,27 +17,9 @@ test("authenticated desktop home does not hydration-mismatch", async ({
     }
   });
 
-  await page.goto("/");
-  await page.getByRole("textbox").first().fill(loginAnswer);
-  await page.getByRole("button", { name: "Login" }).click();
+  await loginAndRevealBrowse(page);
 
   const browseMember = page.getByRole("button", { name: /McPeak/i }).first();
-  const surveyDialog = page.getByRole("dialog", {
-    name: /family reunion interest survey/i,
-  });
-  await Promise.race([
-    browseMember.waitFor({ state: "visible", timeout: 30_000 }),
-    surveyDialog.waitFor({ state: "visible", timeout: 30_000 }),
-  ]);
-  if (await surveyDialog.isVisible().catch(() => false)) {
-    await surveyDialog
-      .getByRole("checkbox", { name: /don't ask again/i })
-      .click();
-    await surveyDialog.getByRole("button", { name: /^close$/i }).click();
-    await expect(surveyDialog).toBeHidden();
-  }
-  await expect(page.locator(".MuiModal-backdrop")).toHaveCount(0);
-  await expect(browseMember).toBeVisible();
 
   // Reloading while authenticated forces SSR of FamilyAppBar, which is where
   // desktop media-query mismatch shows up.

--- a/playwright/smoke.spec.ts
+++ b/playwright/smoke.spec.ts
@@ -1,53 +1,7 @@
-import { expect, type Page, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { loginAndRevealBrowse } from "./helpers";
 
 const loginAnswer = process.env.PLAYWRIGHT_LOGIN_ANSWER ?? "smoke-answer";
-
-async function loginAndRevealBrowse(page: Page): Promise<void> {
-  await page.goto("/");
-  await expect(page.getByText(/family reunion/i)).toBeVisible();
-
-  await page.getByRole("textbox").first().fill(loginAnswer);
-  await page.getByRole("button", { name: "Login" }).click();
-
-  await expect
-    .poll(async () => {
-      const response = await page.request.get("/api/auth/session");
-      if (!response.ok()) {
-        return false;
-      }
-      const body = (await response.json()) as { authenticated?: boolean };
-      return body.authenticated === true;
-    })
-    .toBe(true);
-
-  const membersResponse = await page.request.get("/api/members");
-  expect(membersResponse.status()).toBe(200);
-  const membersPayload = (await membersResponse.json()) as {
-    members: unknown[];
-  };
-  expect(membersPayload.members.length).toBeGreaterThan(0);
-
-  const browseMember = page.getByRole("button", { name: /McPeak/i }).first();
-  const surveyDialog = page.getByRole("dialog", {
-    name: /family reunion interest survey/i,
-  });
-
-  await Promise.race([
-    browseMember.waitFor({ state: "visible", timeout: 30_000 }),
-    surveyDialog.waitFor({ state: "visible", timeout: 30_000 }),
-  ]);
-
-  if (await surveyDialog.isVisible().catch(() => false)) {
-    await surveyDialog
-      .getByRole("checkbox", { name: /don't ask again/i })
-      .click();
-    await surveyDialog.getByRole("button", { name: /^close$/i }).click();
-    await expect(surveyDialog).toBeHidden();
-  }
-
-  await expect(page.locator(".MuiModal-backdrop")).toHaveCount(0);
-  await expect(browseMember).toBeVisible();
-}
 
 test("non-destructive smoke: login, browse, health, export, logout", async ({
   page,

--- a/src/app/api/notify/email/route.test.ts
+++ b/src/app/api/notify/email/route.test.ts
@@ -3,11 +3,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const requireSessionMock = vi.fn();
 const listEmailsMock = vi.fn();
+const listMembersMock = vi.fn();
 const getFamilyRepositoryMock = vi.fn(() => ({
   listEmails: listEmailsMock,
+  listMembers: listMembersMock,
 }));
 const blastSiteLinkMock = vi.fn();
 const resolveEmailSenderMock = vi.fn();
+const resolveNotifyRecipientsMock = vi.fn();
 
 vi.mock("@/lib/api-guard", () => ({
   requireSession: requireSessionMock,
@@ -28,10 +31,12 @@ vi.mock("@/lib/env", () => ({
 vi.mock("@/lib/messaging", () => ({
   blastSiteLink: blastSiteLinkMock,
   resolveEmailSender: resolveEmailSenderMock,
+  resolveNotifyRecipients: resolveNotifyRecipientsMock,
 }));
 
 afterEach(() => {
   vi.clearAllMocks();
+  vi.resetModules();
 });
 
 describe("POST /api/notify/email", () => {
@@ -73,7 +78,7 @@ describe("POST /api/notify/email", () => {
     });
   });
 
-  it("blasts emails when authorized", async () => {
+  it("blasts all emails when memberIds omitted", async () => {
     requireSessionMock.mockResolvedValueOnce(null);
     resolveEmailSenderMock.mockReturnValueOnce({ send: vi.fn() });
     listEmailsMock.mockResolvedValueOnce(["ada@example.com"]);
@@ -101,9 +106,67 @@ describe("POST /api/notify/email", () => {
       failed: 0,
       skipped: 0,
     });
+    expect(listMembersMock).not.toHaveBeenCalled();
     expect(blastSiteLinkMock).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "email",
+        recipients: ["ada@example.com"],
+      }),
+    );
+  });
+
+  it("returns 400 when memberIds is empty", async () => {
+    requireSessionMock.mockResolvedValueOnce(null);
+
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/notify/email", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ memberIds: [] }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "memberIds must not be empty when provided.",
+    });
+    expect(blastSiteLinkMock).not.toHaveBeenCalled();
+  });
+
+  it("blasts emails for selected memberIds only", async () => {
+    requireSessionMock.mockResolvedValueOnce(null);
+    resolveEmailSenderMock.mockReturnValueOnce({ send: vi.fn() });
+    const members = [
+      { id: "member-a", email: "ada@example.com" },
+      { id: "member-b", email: "bob@example.com" },
+    ];
+    listMembersMock.mockResolvedValueOnce(members);
+    resolveNotifyRecipientsMock.mockReturnValueOnce(["ada@example.com"]);
+    blastSiteLinkMock.mockResolvedValueOnce({
+      sent: 1,
+      failed: 0,
+      skipped: 0,
+    });
+
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/notify/email", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ memberIds: ["member-a", "unknown"] }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(listEmailsMock).not.toHaveBeenCalled();
+    expect(resolveNotifyRecipientsMock).toHaveBeenCalledWith({
+      channel: "email",
+      members,
+      memberIds: ["member-a", "unknown"],
+    });
+    expect(blastSiteLinkMock).toHaveBeenCalledWith(
+      expect.objectContaining({
         recipients: ["ada@example.com"],
       }),
     );

--- a/src/app/api/notify/email/route.ts
+++ b/src/app/api/notify/email/route.ts
@@ -4,11 +4,18 @@ import { requireSession } from "@/lib/api-guard";
 import { handleApiError } from "@/lib/api-observability";
 import { getFamilyRepository } from "@/lib/data";
 import { serverEnv } from "@/lib/env";
-import { blastSiteLink, resolveEmailSender } from "@/lib/messaging";
+import {
+  blastSiteLink,
+  resolveEmailSender,
+  resolveNotifyRecipients,
+} from "@/lib/messaging";
 
 const bodySchema = z
   .object({
     dryRun: z.boolean().optional(),
+    memberIds: z.array(z.string().min(1)).optional(),
+    subject: z.string().trim().min(1).max(200).optional(),
+    text: z.string().trim().min(1).max(2000).optional(),
   })
   .optional();
 
@@ -24,6 +31,14 @@ export async function POST(request: Request): Promise<NextResponse> {
     if (!parsed.success) {
       return NextResponse.json(
         { error: "Invalid request body." },
+        { status: 400 },
+      );
+    }
+
+    const memberIds = parsed.data?.memberIds;
+    if (memberIds !== undefined && memberIds.length === 0) {
+      return NextResponse.json(
+        { error: "memberIds must not be empty when provided." },
         { status: 400 },
       );
     }
@@ -50,11 +65,24 @@ export async function POST(request: Request): Promise<NextResponse> {
     }
 
     const repository = getFamilyRepository();
-    const emails = await repository.listEmails();
+    let emails: string[];
+    if (memberIds === undefined) {
+      emails = await repository.listEmails();
+    } else {
+      const members = await repository.listMembers();
+      emails = resolveNotifyRecipients({
+        channel: "email",
+        members,
+        memberIds,
+      });
+    }
+
     const result = await blastSiteLink({
       channel: "email",
       recipients: emails,
       emailSender,
+      subject: parsed.data?.subject,
+      text: parsed.data?.text,
     });
 
     return NextResponse.json({

--- a/src/app/api/notify/sms/route.test.ts
+++ b/src/app/api/notify/sms/route.test.ts
@@ -3,11 +3,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const requireSessionMock = vi.fn();
 const listPhonesMock = vi.fn();
+const listMembersMock = vi.fn();
 const getFamilyRepositoryMock = vi.fn(() => ({
   listPhones: listPhonesMock,
+  listMembers: listMembersMock,
 }));
 const blastSiteLinkMock = vi.fn();
 const resolveSmsSenderMock = vi.fn();
+const resolveNotifyRecipientsMock = vi.fn();
 
 const serverEnvState = {
   messagingDryRun: false,
@@ -30,10 +33,12 @@ vi.mock("@/lib/env", () => ({
 vi.mock("@/lib/messaging", () => ({
   blastSiteLink: blastSiteLinkMock,
   resolveSmsSender: resolveSmsSenderMock,
+  resolveNotifyRecipients: resolveNotifyRecipientsMock,
 }));
 
 afterEach(() => {
   vi.clearAllMocks();
+  vi.resetModules();
   serverEnvState.messagingDryRun = false;
   serverEnvState.smsEnabled = false;
 });
@@ -72,7 +77,7 @@ describe("POST /api/notify/sms", () => {
     });
   });
 
-  it("blasts SMS when enabled", async () => {
+  it("blasts all SMS when enabled and memberIds omitted", async () => {
     requireSessionMock.mockResolvedValueOnce(null);
     serverEnvState.smsEnabled = true;
     resolveSmsSenderMock.mockReturnValueOnce({ send: vi.fn() });
@@ -101,5 +106,65 @@ describe("POST /api/notify/sms", () => {
       failed: 0,
       skipped: 0,
     });
+    expect(listMembersMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when memberIds is empty", async () => {
+    requireSessionMock.mockResolvedValueOnce(null);
+    serverEnvState.smsEnabled = true;
+
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/notify/sms", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ memberIds: [] }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "memberIds must not be empty when provided.",
+    });
+    expect(blastSiteLinkMock).not.toHaveBeenCalled();
+  });
+
+  it("blasts SMS for selected memberIds only", async () => {
+    requireSessionMock.mockResolvedValueOnce(null);
+    serverEnvState.smsEnabled = true;
+    resolveSmsSenderMock.mockReturnValueOnce({ send: vi.fn() });
+    const members = [
+      { id: "member-a", phone: "555-111-2222" },
+      { id: "member-b", phone: "555-333-4444" },
+    ];
+    listMembersMock.mockResolvedValueOnce(members);
+    resolveNotifyRecipientsMock.mockReturnValueOnce(["555-111-2222"]);
+    blastSiteLinkMock.mockResolvedValueOnce({
+      sent: 1,
+      failed: 0,
+      skipped: 0,
+    });
+
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/notify/sms", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ memberIds: ["member-a"] }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(listPhonesMock).not.toHaveBeenCalled();
+    expect(resolveNotifyRecipientsMock).toHaveBeenCalledWith({
+      channel: "sms",
+      members,
+      memberIds: ["member-a"],
+    });
+    expect(blastSiteLinkMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipients: ["555-111-2222"],
+      }),
+    );
   });
 });

--- a/src/app/api/notify/sms/route.ts
+++ b/src/app/api/notify/sms/route.ts
@@ -4,11 +4,17 @@ import { requireSession } from "@/lib/api-guard";
 import { handleApiError } from "@/lib/api-observability";
 import { getFamilyRepository } from "@/lib/data";
 import { serverEnv } from "@/lib/env";
-import { blastSiteLink, resolveSmsSender } from "@/lib/messaging";
+import {
+  blastSiteLink,
+  resolveNotifyRecipients,
+  resolveSmsSender,
+} from "@/lib/messaging";
 
 const bodySchema = z
   .object({
     dryRun: z.boolean().optional(),
+    memberIds: z.array(z.string().min(1)).optional(),
+    text: z.string().trim().min(1).max(2000).optional(),
   })
   .optional();
 
@@ -24,6 +30,14 @@ export async function POST(request: Request): Promise<NextResponse> {
     if (!parsed.success) {
       return NextResponse.json(
         { error: "Invalid request body." },
+        { status: 400 },
+      );
+    }
+
+    const memberIds = parsed.data?.memberIds;
+    if (memberIds !== undefined && memberIds.length === 0) {
+      return NextResponse.json(
+        { error: "memberIds must not be empty when provided." },
         { status: 400 },
       );
     }
@@ -60,11 +74,23 @@ export async function POST(request: Request): Promise<NextResponse> {
     }
 
     const repository = getFamilyRepository();
-    const phones = await repository.listPhones();
+    let phones: string[];
+    if (memberIds === undefined) {
+      phones = await repository.listPhones();
+    } else {
+      const members = await repository.listMembers();
+      phones = resolveNotifyRecipients({
+        channel: "sms",
+        members,
+        memberIds,
+      });
+    }
+
     const result = await blastSiteLink({
       channel: "sms",
       recipients: phones,
       smsSender,
+      text: parsed.data?.text,
     });
 
     return NextResponse.json({

--- a/src/components/family-app.tsx
+++ b/src/components/family-app.tsx
@@ -821,9 +821,7 @@ export function FamilyApp({
         />
         <ConfirmDialog
           open={confirmNotifyChannel !== null}
-          title={
-            confirmNotifyChannel === "sms" ? "Send text?" : "Send email?"
-          }
+          title={confirmNotifyChannel === "sms" ? "Send text?" : "Send email?"}
           description={
             confirmNotifyChannel === "sms"
               ? `Send this message to ${selectedSmsMemberIds.length} selected recipient${selectedSmsMemberIds.length === 1 ? "" : "s"} by text?`

--- a/src/components/family-app.tsx
+++ b/src/components/family-app.tsx
@@ -15,6 +15,7 @@ import {
   useSearchParams,
 } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { NotifyRecipientOption } from "@/components/family/app-dialogs";
 import { AppMenus } from "@/components/family/app-menus";
 import { BrowseSearchProvider } from "@/components/family/browse-search-context";
 import { BrowseShell } from "@/components/family/browse-shell";
@@ -43,8 +44,6 @@ import {
 import { buildDisplayNameOptions, formatMemberName } from "@/lib/member-utils";
 import { siteLinkEmailContent } from "@/lib/messaging/templates";
 import {
-  fetchEmails,
-  fetchPhones,
   isUnauthorizedError,
   notifyEmailBlast,
   notifySmsBlast,
@@ -73,6 +72,44 @@ const DEFAULT_PARENT_OPTIONS: ParentOption[] = [
   { id: "", firstName: "", lastName: "" },
 ];
 const EMPTY_DISPLAY_NAME_OPTIONS: string[] = [];
+const EMPTY_NOTIFY_RECIPIENTS: NotifyRecipientOption[] = [];
+
+function buildEmailNotifyRecipients(
+  members: FamilyMemberRecord[],
+): NotifyRecipientOption[] {
+  const options: NotifyRecipientOption[] = [];
+  for (const member of members) {
+    const email = typeof member.email === "string" ? member.email.trim() : "";
+    if (email.length <= 4) {
+      continue;
+    }
+    options.push({
+      id: member.id,
+      label: formatMemberName(member),
+      contact: email,
+    });
+  }
+  return options;
+}
+
+function buildSmsNotifyRecipients(
+  members: FamilyMemberRecord[],
+): NotifyRecipientOption[] {
+  const options: NotifyRecipientOption[] = [];
+  for (const member of members) {
+    const phone = member.phone;
+    const trimmed = typeof phone === "string" ? phone.trim() : "";
+    if (!trimmed) {
+      continue;
+    }
+    options.push({
+      id: member.id,
+      label: formatMemberName(member),
+      contact: trimmed,
+    });
+  }
+  return options;
+}
 
 function displayNameSignature(member: FamilyMemberRecord | null): string {
   if (!member) {
@@ -164,10 +201,14 @@ export function FamilyApp({
   const [showEmails, setShowEmails] = useState(false);
   const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
-  const [emailsText, setEmailsText] = useState("");
-  const [emailCount, setEmailCount] = useState(0);
-  const [phoneCount, setPhoneCount] = useState(0);
-  const [copiedEmailText, setCopiedEmailText] = useState(false);
+  const [selectedEmailMemberIds, setSelectedEmailMemberIds] = useState<
+    string[]
+  >([]);
+  const [selectedSmsMemberIds, setSelectedSmsMemberIds] = useState<string[]>(
+    [],
+  );
+  const [notifySubject, setNotifySubject] = useState("");
+  const [notifyBody, setNotifyBody] = useState("");
   const [sendingChannel, setSendingChannel] = useState<"email" | "sms" | null>(
     null,
   );
@@ -242,10 +283,33 @@ export function FamilyApp({
   const loginBusy = loginMutation.isPending;
   const saveEnabled = !!selectedUser && dirty && !saving;
 
+  const emailRecipients = useMemo(
+    () =>
+      members.length === 0
+        ? EMPTY_NOTIFY_RECIPIENTS
+        : buildEmailNotifyRecipients(members),
+    [members],
+  );
+  const smsRecipients = useMemo(
+    () =>
+      members.length === 0
+        ? EMPTY_NOTIFY_RECIPIENTS
+        : buildSmsNotifyRecipients(members),
+    [members],
+  );
+  const emailsText = useMemo(() => {
+    const contactById = new Map(
+      emailRecipients.map((option) => [option.id, option.contact]),
+    );
+    return selectedEmailMemberIds
+      .map((id) => contactById.get(id))
+      .filter((value): value is string => typeof value === "string")
+      .join("; ");
+  }, [emailRecipients, selectedEmailMemberIds]);
+
   const resetDirty = useCallback((): void => {
     setDirty(false);
   }, [setDirty]);
-
   const navigation = useFamilyNavigation({
     routeMemberId,
     routeTab,
@@ -459,35 +523,14 @@ export function FamilyApp({
     window.location.href = "/api/export/mailing";
   };
 
-  const openEmailsDialog = async (): Promise<void> => {
-    try {
-      const [emailsPayload, phonesPayload] = await Promise.all([
-        queryClient.fetchQuery({
-          queryKey: familyKeys.emails(),
-          queryFn: fetchEmails,
-        }),
-        queryClient.fetchQuery({
-          queryKey: familyKeys.phones(),
-          queryFn: fetchPhones,
-        }),
-      ]);
-      setEmailsText(emailsPayload.emails.join("; "));
-      setEmailCount(emailsPayload.emails.length);
-      setPhoneCount(phonesPayload.phones.length);
-      setCopiedEmailText(false);
-      setBlastResult(null);
-      setShowEmails(true);
-    } catch (caughtError) {
-      if (isUnauthorizedError(caughtError)) {
-        queryClient.setQueryData(familyKeys.session(), {
-          authenticated: false,
-        });
-        return;
-      }
-      reportError(
-        caughtError instanceof Error ? caughtError.message : "Unknown error",
-      );
-    }
+  const openEmailsDialog = (): void => {
+    const defaults = siteLinkEmailContent();
+    setNotifySubject(defaults.subject);
+    setNotifyBody(defaults.text);
+    setSelectedEmailMemberIds(emailRecipients.map((option) => option.id));
+    setSelectedSmsMemberIds(smsRecipients.map((option) => option.id));
+    setBlastResult(null);
+    setShowEmails(true);
   };
 
   const copyEmails = async (): Promise<void> => {
@@ -497,7 +540,7 @@ export function FamilyApp({
     clearError();
     try {
       await navigator.clipboard.writeText(emailsText);
-      setCopiedEmailText(true);
+      reportSuccess("Emails copied to clipboard.");
     } catch (caughtError) {
       reportError(
         caughtError instanceof Error ? caughtError.message : "Unknown error",
@@ -511,8 +554,19 @@ export function FamilyApp({
     setBlastResult(null);
     clearError();
     try {
+      const memberIds =
+        channel === "email" ? selectedEmailMemberIds : selectedSmsMemberIds;
       const result =
-        channel === "email" ? await notifyEmailBlast() : await notifySmsBlast();
+        channel === "email"
+          ? await notifyEmailBlast({
+              memberIds,
+              subject: notifySubject.trim(),
+              text: notifyBody.trim(),
+            })
+          : await notifySmsBlast({
+              memberIds,
+              text: notifyBody.trim(),
+            });
       setBlastResult(
         `${channel === "email" ? "Email" : "SMS"} blast finished: ${result.sent} sent, ${result.failed} failed, ${result.skipped} skipped${result.dryRun ? " (dry run)" : ""}.`,
       );
@@ -576,8 +630,6 @@ export function FamilyApp({
     setConfirmNotifyChannel(null);
   }, []);
 
-  const notifyMessagePreview = useMemo(() => siteLinkEmailContent().text, []);
-
   const confirmDiscard = useCallback((): void => {
     setConfirmDiscardOpen(false);
     beginAddMember();
@@ -595,7 +647,7 @@ export function FamilyApp({
     <Snackbar
       open={snackbarOpen}
       autoHideDuration={snackbarSeverity === "success" ? 4000 : null}
-      anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
       onClose={(_, reason) => {
         if (reason === "clickaway") {
           return;
@@ -776,8 +828,8 @@ export function FamilyApp({
           }
           description={
             confirmNotifyChannel === "sms"
-              ? `Text the site link to ${phoneCount} phone number${phoneCount === 1 ? "" : "s"} on file?`
-              : `Email the site link to ${emailCount} address${emailCount === 1 ? "" : "es"} on file?`
+              ? `Text the site link to ${selectedSmsMemberIds.length} selected phone number${selectedSmsMemberIds.length === 1 ? "" : "s"}?`
+              : `Email the site link to ${selectedEmailMemberIds.length} selected address${selectedEmailMemberIds.length === 1 ? "" : "es"}?`
           }
           confirmLabel={
             confirmNotifyChannel === "sms" ? "Send SMS" : "Send email"
@@ -794,10 +846,16 @@ export function FamilyApp({
             open={showEmails}
             onClose={closeEmailsDialog}
             emailsText={emailsText}
-            emailCount={emailCount}
-            phoneCount={phoneCount}
-            messagePreview={notifyMessagePreview}
-            copiedEmailText={copiedEmailText}
+            emailRecipients={emailRecipients}
+            smsRecipients={smsRecipients}
+            selectedEmailMemberIds={selectedEmailMemberIds}
+            selectedSmsMemberIds={selectedSmsMemberIds}
+            onSelectedEmailMemberIdsChange={setSelectedEmailMemberIds}
+            onSelectedSmsMemberIdsChange={setSelectedSmsMemberIds}
+            messageSubject={notifySubject}
+            onMessageSubjectChange={setNotifySubject}
+            messageBody={notifyBody}
+            onMessageBodyChange={setNotifyBody}
             sendingChannel={sendingChannel}
             blastResult={blastResult}
             onCopyEmails={copyEmails}

--- a/src/components/family-app.tsx
+++ b/src/components/family-app.tsx
@@ -568,7 +568,7 @@ export function FamilyApp({
               text: notifyBody.trim(),
             });
       setBlastResult(
-        `${channel === "email" ? "Email" : "SMS"} blast finished: ${result.sent} sent, ${result.failed} failed, ${result.skipped} skipped${result.dryRun ? " (dry run)" : ""}.`,
+        `${channel === "email" ? "Email" : "Text"} sent: ${result.sent} delivered, ${result.failed} failed, ${result.skipped} skipped${result.dryRun ? " (dry run)" : ""}.`,
       );
     } catch (caughtError) {
       if (isUnauthorizedError(caughtError)) {
@@ -822,17 +822,15 @@ export function FamilyApp({
         <ConfirmDialog
           open={confirmNotifyChannel !== null}
           title={
-            confirmNotifyChannel === "sms"
-              ? "Send SMS blast?"
-              : "Send email blast?"
+            confirmNotifyChannel === "sms" ? "Send text?" : "Send email?"
           }
           description={
             confirmNotifyChannel === "sms"
-              ? `Text the site link to ${selectedSmsMemberIds.length} selected phone number${selectedSmsMemberIds.length === 1 ? "" : "s"}?`
-              : `Email the site link to ${selectedEmailMemberIds.length} selected address${selectedEmailMemberIds.length === 1 ? "" : "es"}?`
+              ? `Send this message to ${selectedSmsMemberIds.length} selected recipient${selectedSmsMemberIds.length === 1 ? "" : "s"} by text?`
+              : `Send this message to ${selectedEmailMemberIds.length} selected recipient${selectedEmailMemberIds.length === 1 ? "" : "s"} by email?`
           }
           confirmLabel={
-            confirmNotifyChannel === "sms" ? "Send SMS" : "Send email"
+            confirmNotifyChannel === "sms" ? "Send text" : "Send email"
           }
           onConfirm={() => {
             if (confirmNotifyChannel) {

--- a/src/components/family/app-dialogs.test.tsx
+++ b/src/components/family/app-dialogs.test.tsx
@@ -71,21 +71,19 @@ describe("EmailsDialog", () => {
     );
 
     expect(
-      screen.getByRole("button", { name: "Send email blast" }),
+      screen.getByRole("button", { name: "Send email" }),
     ).toBeDisabled();
-    expect(
-      screen.getByRole("button", { name: "Send SMS blast" }),
-    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Send text" })).toBeDisabled();
   });
 
   it("disables email send when subject is empty", () => {
     render(<EmailsDialog {...baseProps} messageSubject="   " />);
 
     expect(
-      screen.getByRole("button", { name: "Send email blast" }),
+      screen.getByRole("button", { name: "Send email" }),
     ).toBeDisabled();
     expect(
-      screen.getByRole("button", { name: "Send SMS blast" }),
+      screen.getByRole("button", { name: "Send text" }),
     ).not.toBeDisabled();
   });
 

--- a/src/components/family/app-dialogs.test.tsx
+++ b/src/components/family/app-dialogs.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/build-info", () => ({
@@ -8,7 +8,7 @@ vi.mock("@/lib/build-info", () => ({
   },
 }));
 
-import { AboutDialog } from "@/components/family/app-dialogs";
+import { AboutDialog, EmailsDialog } from "@/components/family/app-dialogs";
 
 describe("AboutDialog", () => {
   it("shows build details and support links", () => {
@@ -26,5 +26,115 @@ describe("AboutDialog", () => {
       "href",
       "https://github.com/jmcpeak/family/issues",
     );
+  });
+});
+
+describe("EmailsDialog", () => {
+  const emailRecipients = [
+    { id: "m1", label: "Ada Lovelace", contact: "ada@example.com" },
+    { id: "m2", label: "Bob Builder", contact: "bob@example.com" },
+  ];
+  const smsRecipients = [
+    { id: "m1", label: "Ada Lovelace", contact: "555-111-2222" },
+  ];
+
+  const baseProps = {
+    open: true,
+    onClose: vi.fn(),
+    emailsText: "ada@example.com; bob@example.com",
+    emailRecipients,
+    smsRecipients,
+    selectedEmailMemberIds: ["m1", "m2"] as string[],
+    selectedSmsMemberIds: ["m1"] as string[],
+    onSelectedEmailMemberIdsChange: vi.fn(),
+    onSelectedSmsMemberIdsChange: vi.fn(),
+    messageSubject: "McPeak family directory",
+    onMessageSubjectChange: vi.fn(),
+    messageBody: "Hello family",
+    onMessageBodyChange: vi.fn(),
+    sendingChannel: null as "email" | "sms" | null,
+    blastResult: null as string | null,
+    onCopyEmails: vi.fn(),
+    onSendEmailBlast: vi.fn(),
+    onSendSmsBlast: vi.fn(),
+    fullScreen: false,
+  };
+
+  it("disables send buttons when no recipients are selected", () => {
+    render(
+      <EmailsDialog
+        {...baseProps}
+        selectedEmailMemberIds={[]}
+        selectedSmsMemberIds={[]}
+        emailsText=""
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Send email blast" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Send SMS blast" }),
+    ).toBeDisabled();
+  });
+
+  it("disables email send when subject is empty", () => {
+    render(<EmailsDialog {...baseProps} messageSubject="   " />);
+
+    expect(
+      screen.getByRole("button", { name: "Send email blast" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Send SMS blast" }),
+    ).not.toBeDisabled();
+  });
+
+  it("selects all and clears email recipients", () => {
+    const onEmailChange = vi.fn();
+    render(
+      <EmailsDialog
+        {...baseProps}
+        selectedEmailMemberIds={["m1"]}
+        onSelectedEmailMemberIdsChange={onEmailChange}
+      />,
+    );
+
+    const selectAllButton = screen.getAllByRole("button", {
+      name: "Select all",
+    })[0];
+    const clearButton = screen.getAllByRole("button", { name: "Clear" })[0];
+    expect(selectAllButton).toBeDefined();
+    expect(clearButton).toBeDefined();
+    if (!selectAllButton || !clearButton) {
+      return;
+    }
+
+    fireEvent.click(selectAllButton);
+    expect(onEmailChange).toHaveBeenCalledWith(["m1", "m2"]);
+
+    fireEvent.click(clearButton);
+    expect(onEmailChange).toHaveBeenCalledWith([]);
+  });
+
+  it("edits subject and body fields", () => {
+    const onSubjectChange = vi.fn();
+    const onBodyChange = vi.fn();
+    render(
+      <EmailsDialog
+        {...baseProps}
+        onMessageSubjectChange={onSubjectChange}
+        onMessageBodyChange={onBodyChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Subject (email)"), {
+      target: { value: "Reunion update" },
+    });
+    fireEvent.change(screen.getByLabelText("Message"), {
+      target: { value: "Please update your info." },
+    });
+
+    expect(onSubjectChange).toHaveBeenCalledWith("Reunion update");
+    expect(onBodyChange).toHaveBeenCalledWith("Please update your info.");
   });
 });

--- a/src/components/family/app-dialogs.test.tsx
+++ b/src/components/family/app-dialogs.test.tsx
@@ -70,18 +70,14 @@ describe("EmailsDialog", () => {
       />,
     );
 
-    expect(
-      screen.getByRole("button", { name: "Send email" }),
-    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Send email" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Send text" })).toBeDisabled();
   });
 
   it("disables email send when subject is empty", () => {
     render(<EmailsDialog {...baseProps} messageSubject="   " />);
 
-    expect(
-      screen.getByRole("button", { name: "Send email" }),
-    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Send email" })).toBeDisabled();
     expect(
       screen.getByRole("button", { name: "Send text" }),
     ).not.toBeDisabled();

--- a/src/components/family/app-dialogs.tsx
+++ b/src/components/family/app-dialogs.tsx
@@ -255,8 +255,8 @@ export function EmailsDialog({
       <DialogContent>
         <Typography color="text.secondary" sx={{ mb: 2 }}>
           Edit the message, choose recipients (defaults to everyone eligible),
-          then send. Subject applies to email only; the body is used for email
-          and SMS.
+          then send. Subject applies to email only; the message body is used for
+          both email and text.
         </Typography>
         <TextField
           label="Subject (email)"
@@ -275,7 +275,7 @@ export function EmailsDialog({
           fullWidth
           disabled={busy}
           sx={{ mb: 2 }}
-          helperText={`${messageBody.length} characters — keep SMS under ~160 if possible`}
+          helperText={`${messageBody.length} characters — keep texts under ~160 if possible`}
         />
         <NotifyRecipientPicker
           label="Email recipients"
@@ -285,7 +285,7 @@ export function EmailsDialog({
           disabled={busy}
         />
         <NotifyRecipientPicker
-          label="SMS recipients"
+          label="Text recipients"
           options={smsRecipients}
           selectedIds={selectedSmsMemberIds}
           onChange={onSelectedSmsMemberIdsChange}
@@ -308,7 +308,7 @@ export function EmailsDialog({
             !hasBody
           }
         >
-          {sendingChannel === "email" ? "Sending email…" : "Send email blast"}
+          {sendingChannel === "email" ? "Sending email…" : "Send email"}
         </Button>
         <Button
           onClick={() => void onSendSmsBlast()}
@@ -316,7 +316,7 @@ export function EmailsDialog({
           color="secondary"
           disabled={busy || selectedSmsMemberIds.length === 0 || !hasBody}
         >
-          {sendingChannel === "sms" ? "Sending SMS…" : "Send SMS blast"}
+          {sendingChannel === "sms" ? "Sending text…" : "Send text"}
         </Button>
         <Button
           onClick={() => void onCopyEmails()}

--- a/src/components/family/app-dialogs.tsx
+++ b/src/components/family/app-dialogs.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import Alert from "@mui/material/Alert";
+import Autocomplete from "@mui/material/Autocomplete";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Checkbox from "@mui/material/Checkbox";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
@@ -101,14 +103,113 @@ export function AboutDialog({
   );
 }
 
+export interface NotifyRecipientOption {
+  id: string;
+  label: string;
+  contact: string;
+}
+
+interface NotifyRecipientPickerProps {
+  label: string;
+  options: NotifyRecipientOption[];
+  selectedIds: string[];
+  onChange: (ids: string[]) => void;
+  disabled: boolean;
+}
+
+function NotifyRecipientPicker({
+  label,
+  options,
+  selectedIds,
+  onChange,
+  disabled,
+}: NotifyRecipientPickerProps): React.JSX.Element {
+  const selected = options.filter((option) => selectedIds.includes(option.id));
+  const allSelected =
+    options.length > 0 && selectedIds.length === options.length;
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Stack
+        direction="row"
+        spacing={1}
+        sx={{ alignItems: "center", justifyContent: "space-between", mb: 0.5 }}
+      >
+        <Typography variant="subtitle2">{label}</Typography>
+        <Stack direction="row" spacing={1}>
+          <Button
+            size="small"
+            onClick={() => onChange(options.map((option) => option.id))}
+            disabled={disabled || options.length === 0 || allSelected}
+          >
+            Select all
+          </Button>
+          <Button
+            size="small"
+            onClick={() => onChange([])}
+            disabled={disabled || selectedIds.length === 0}
+          >
+            Clear
+          </Button>
+        </Stack>
+      </Stack>
+      <Autocomplete
+        multiple
+        disableCloseOnSelect
+        options={options}
+        value={selected}
+        onChange={(_event, next) => {
+          onChange(next.map((option) => option.id));
+        }}
+        getOptionLabel={(option) => `${option.label} (${option.contact})`}
+        isOptionEqualToValue={(option, value) => option.id === value.id}
+        disabled={disabled || options.length === 0}
+        renderOption={(props, option, { selected: optionSelected }) => {
+          const { key, ...optionProps } = props;
+          return (
+            <li key={key} {...optionProps}>
+              <Checkbox
+                size="small"
+                checked={optionSelected}
+                sx={{ mr: 1 }}
+                tabIndex={-1}
+                disableRipple
+              />
+              <Box>
+                <Typography variant="body2">{option.label}</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {option.contact}
+                </Typography>
+              </Box>
+            </li>
+          );
+        }}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label={`${selectedIds.length} of ${options.length} selected`}
+            placeholder={options.length === 0 ? "None on file" : "Search…"}
+          />
+        )}
+      />
+    </Box>
+  );
+}
+
 interface EmailsDialogProps {
   open: boolean;
   onClose: () => void;
   emailsText: string;
-  emailCount: number;
-  phoneCount: number;
-  messagePreview: string;
-  copiedEmailText: boolean;
+  emailRecipients: NotifyRecipientOption[];
+  smsRecipients: NotifyRecipientOption[];
+  selectedEmailMemberIds: string[];
+  selectedSmsMemberIds: string[];
+  onSelectedEmailMemberIdsChange: (ids: string[]) => void;
+  onSelectedSmsMemberIdsChange: (ids: string[]) => void;
+  messageSubject: string;
+  onMessageSubjectChange: (value: string) => void;
+  messageBody: string;
+  onMessageBodyChange: (value: string) => void;
   sendingChannel: "email" | "sms" | null;
   blastResult: string | null;
   onCopyEmails: () => void | Promise<void>;
@@ -121,10 +222,16 @@ export function EmailsDialog({
   open,
   onClose,
   emailsText,
-  emailCount,
-  phoneCount,
-  messagePreview,
-  copiedEmailText,
+  emailRecipients,
+  smsRecipients,
+  selectedEmailMemberIds,
+  selectedSmsMemberIds,
+  onSelectedEmailMemberIdsChange,
+  onSelectedSmsMemberIdsChange,
+  messageSubject,
+  onMessageSubjectChange,
+  messageBody,
+  onMessageBodyChange,
   sendingChannel,
   blastResult,
   onCopyEmails,
@@ -133,6 +240,8 @@ export function EmailsDialog({
   fullScreen,
 }: EmailsDialogProps): React.JSX.Element {
   const busy = sendingChannel !== null;
+  const hasSubject = messageSubject.trim().length > 0;
+  const hasBody = messageBody.trim().length > 0;
 
   return (
     <Dialog
@@ -142,49 +251,46 @@ export function EmailsDialog({
       fullWidth
       fullScreen={fullScreen}
     >
-      <DialogTitle>Notify family</DialogTitle>
+      <DialogTitle>Email or text family</DialogTitle>
       <DialogContent>
         <Typography color="text.secondary" sx={{ mb: 2 }}>
-          Send the site link to members on file, or copy email addresses for a
-          manual message. The login answer is not included — recipients already
-          know it.
-        </Typography>
-        <Typography variant="body2" sx={{ mb: 1 }}>
-          On file: {emailCount} email{emailCount === 1 ? "" : "s"}, {phoneCount}{" "}
-          phone{phoneCount === 1 ? "" : "s"}
-        </Typography>
-        <Typography
-          variant="body2"
-          component="pre"
-          sx={{
-            mb: 2,
-            p: 1.5,
-            bgcolor: "action.hover",
-            borderRadius: 1,
-            whiteSpace: "pre-wrap",
-            fontFamily: "inherit",
-          }}
-        >
-          {messagePreview}
+          Edit the message, choose recipients (defaults to everyone eligible),
+          then send. Subject applies to email only; the body is used for email
+          and SMS.
         </Typography>
         <TextField
-          label="Email addresses"
-          value={emailsText}
-          multiline
-          rows={6}
+          label="Subject (email)"
+          value={messageSubject}
+          onChange={(event) => onMessageSubjectChange(event.target.value)}
           fullWidth
-          slotProps={{
-            htmlInput: {
-              "aria-label": "Bulk email addresses",
-              readOnly: true,
-            },
-          }}
+          disabled={busy}
+          sx={{ mb: 2 }}
         />
-        {copiedEmailText ? (
-          <Alert severity="success" sx={{ mt: 1 }}>
-            Copied to clipboard.
-          </Alert>
-        ) : null}
+        <TextField
+          label="Message"
+          value={messageBody}
+          onChange={(event) => onMessageBodyChange(event.target.value)}
+          multiline
+          minRows={4}
+          fullWidth
+          disabled={busy}
+          sx={{ mb: 2 }}
+          helperText={`${messageBody.length} characters — keep SMS under ~160 if possible`}
+        />
+        <NotifyRecipientPicker
+          label="Email recipients"
+          options={emailRecipients}
+          selectedIds={selectedEmailMemberIds}
+          onChange={onSelectedEmailMemberIdsChange}
+          disabled={busy}
+        />
+        <NotifyRecipientPicker
+          label="SMS recipients"
+          options={smsRecipients}
+          selectedIds={selectedSmsMemberIds}
+          onChange={onSelectedSmsMemberIdsChange}
+          disabled={busy}
+        />
         {blastResult ? (
           <Alert severity="info" sx={{ mt: 1 }}>
             {blastResult}
@@ -195,7 +301,12 @@ export function EmailsDialog({
         <Button
           onClick={() => void onSendEmailBlast()}
           variant="contained"
-          disabled={busy || emailCount === 0}
+          disabled={
+            busy ||
+            selectedEmailMemberIds.length === 0 ||
+            !hasSubject ||
+            !hasBody
+          }
         >
           {sendingChannel === "email" ? "Sending email…" : "Send email blast"}
         </Button>
@@ -203,12 +314,13 @@ export function EmailsDialog({
           onClick={() => void onSendSmsBlast()}
           variant="contained"
           color="secondary"
-          disabled={busy || phoneCount === 0}
+          disabled={busy || selectedSmsMemberIds.length === 0 || !hasBody}
         >
           {sendingChannel === "sms" ? "Sending SMS…" : "Send SMS blast"}
         </Button>
         <Button
           onClick={() => void onCopyEmails()}
+          variant="outlined"
           disabled={busy || !emailsText}
         >
           Copy emails

--- a/src/components/family/app-menus.tsx
+++ b/src/components/family/app-menus.tsx
@@ -129,7 +129,7 @@ export function AppMenus({
               <ListItemIcon>
                 <EmailIcon fontSize="small" />
               </ListItemIcon>
-              Email or text family
+              Email or text
             </MenuItem>
             <MenuItem onClick={() => runMoreAction(onExportMailingLabels)}>
               <ListItemIcon>

--- a/src/components/family/app-menus.tsx
+++ b/src/components/family/app-menus.tsx
@@ -129,7 +129,7 @@ export function AppMenus({
               <ListItemIcon>
                 <EmailIcon fontSize="small" />
               </ListItemIcon>
-              Notify family
+              Email or text family
             </MenuItem>
             <MenuItem onClick={() => runMoreAction(onExportMailingLabels)}>
               <ListItemIcon>

--- a/src/lib/messaging/blast.test.ts
+++ b/src/lib/messaging/blast.test.ts
@@ -78,4 +78,41 @@ describe("blastSiteLink", () => {
       text: expect.stringContaining("mcpeakfamily.org"),
     });
   });
+
+  it("uses custom subject and body for email", async () => {
+    const send = vi.fn(async () => undefined);
+    const emailSender: EmailSender = { send };
+
+    await blastSiteLink({
+      channel: "email",
+      recipients: ["ada@example.com"],
+      emailSender,
+      subject: "Custom subject",
+      text: "Line one\nhttps://mcpeakfamily.org\nLine three",
+    });
+
+    expect(send).toHaveBeenCalledWith({
+      to: "ada@example.com",
+      subject: "Custom subject",
+      text: "Line one\nhttps://mcpeakfamily.org\nLine three",
+      html: expect.stringContaining("https://mcpeakfamily.org"),
+    });
+  });
+
+  it("uses custom body for SMS", async () => {
+    const send = vi.fn(async () => undefined);
+    const smsSender: SmsSender = { send };
+
+    await blastSiteLink({
+      channel: "sms",
+      recipients: ["555-012-3456"],
+      smsSender,
+      text: "Custom SMS body",
+    });
+
+    expect(send).toHaveBeenCalledWith({
+      toE164: "+15550123456",
+      text: "Custom SMS body",
+    });
+  });
 });

--- a/src/lib/messaging/blast.ts
+++ b/src/lib/messaging/blast.ts
@@ -1,5 +1,9 @@
 import { normalizePhoneToE164 } from "./phone";
-import { siteLinkEmailContent, siteLinkSmsContent } from "./templates";
+import {
+  plainTextToSimpleHtml,
+  siteLinkEmailContent,
+  siteLinkSmsContent,
+} from "./templates";
 import type {
   BlastResult,
   EmailSender,
@@ -16,6 +20,10 @@ export interface BlastSiteLinkOptions {
   smsSender?: SmsSender;
   siteUrl?: string;
   concurrency?: number;
+  /** Email subject override; defaults to template subject. */
+  subject?: string;
+  /** Plain-text body override; defaults to channel template. */
+  text?: string;
 }
 
 function uniqueEmails(recipients: string[]): {
@@ -123,14 +131,18 @@ export async function blastSiteLink(
       throw new Error("emailSender is required for email blasts.");
     }
     const { emails, skipped } = uniqueEmails(options.recipients);
-    const content = siteLinkEmailContent(options.siteUrl);
+    const defaults = siteLinkEmailContent(options.siteUrl);
+    const subject = options.subject?.trim() || defaults.subject;
+    const text = options.text?.trim() || defaults.text;
+    const html =
+      options.text !== undefined ? plainTextToSimpleHtml(text) : defaults.html;
     const emailSender = options.emailSender;
     const { sent, failed } = await mapPool(emails, concurrency, async (to) => {
       await emailSender.send({
         to,
-        subject: content.subject,
-        text: content.text,
-        html: content.html,
+        subject,
+        text,
+        html,
       });
     });
     return { sent, failed, skipped };
@@ -141,7 +153,7 @@ export async function blastSiteLink(
   }
 
   const { phones, skipped } = uniquePhones(options.recipients);
-  const text = siteLinkSmsContent(options.siteUrl);
+  const text = options.text?.trim() || siteLinkSmsContent(options.siteUrl);
   const smsSender = options.smsSender;
   const { sent, failed } = await mapPool(
     phones,

--- a/src/lib/messaging/index.ts
+++ b/src/lib/messaging/index.ts
@@ -6,7 +6,9 @@ import type { EmailSender, SmsSender } from "./types";
 export type { BlastSiteLinkOptions } from "./blast";
 export { blastSiteLink } from "./blast";
 export { normalizePhoneToE164 } from "./phone";
+export { resolveNotifyRecipients } from "./resolve-recipients";
 export {
+  plainTextToSimpleHtml,
   resolveSiteUrl,
   siteLinkEmailContent,
   siteLinkSmsContent,

--- a/src/lib/messaging/resolve-recipients.test.ts
+++ b/src/lib/messaging/resolve-recipients.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { FamilyMemberRecord } from "@/lib/types";
+import { resolveNotifyRecipients } from "./resolve-recipients";
+
+const members: FamilyMemberRecord[] = [
+  {
+    id: "member-a",
+    firstName: "Ada",
+    lastName: "Lovelace",
+    email: "ada@example.com",
+    phone: "555-111-2222",
+  },
+  {
+    id: "member-b",
+    firstName: "Bob",
+    lastName: "Builder",
+    email: "bob@example.com",
+  },
+  {
+    id: "member-c",
+    firstName: "Cara",
+    lastName: "Phone",
+    phone: "555-333-4444",
+  },
+  {
+    id: "member-d",
+    firstName: "Dan",
+    lastName: "Short",
+    email: "a@b",
+  },
+];
+
+describe("resolveNotifyRecipients", () => {
+  it("resolves emails for requested member ids only", () => {
+    expect(
+      resolveNotifyRecipients({
+        channel: "email",
+        members,
+        memberIds: ["member-a", "member-c", "unknown"],
+      }),
+    ).toEqual(["ada@example.com"]);
+  });
+
+  it("resolves phones for requested member ids only", () => {
+    expect(
+      resolveNotifyRecipients({
+        channel: "sms",
+        members,
+        memberIds: ["member-a", "member-b", "member-c"],
+      }),
+    ).toEqual(["555-111-2222", "555-333-4444"]);
+  });
+
+  it("skips short emails", () => {
+    expect(
+      resolveNotifyRecipients({
+        channel: "email",
+        members,
+        memberIds: ["member-d"],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/src/lib/messaging/resolve-recipients.ts
+++ b/src/lib/messaging/resolve-recipients.ts
@@ -1,0 +1,43 @@
+import type { FamilyMemberRecord } from "@/lib/types";
+import type { MessagingChannel } from "./types";
+
+function memberEmail(member: FamilyMemberRecord): string | null {
+  const email = typeof member.email === "string" ? member.email.trim() : "";
+  if (email.length <= 4) {
+    return null;
+  }
+  return email;
+}
+
+function memberPhone(member: FamilyMemberRecord): string | null {
+  const phone = member.phone;
+  const trimmed = typeof phone === "string" ? phone.trim() : "";
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed;
+}
+
+/**
+ * Resolve blast recipients from member records.
+ * When `memberIds` is provided, only those members are considered (contacts
+ * still come from server-side records — never from the client).
+ */
+export function resolveNotifyRecipients(options: {
+  channel: MessagingChannel;
+  members: FamilyMemberRecord[];
+  memberIds: string[];
+}): string[] {
+  const idSet = new Set(options.memberIds);
+  const selected = options.members.filter((member) => idSet.has(member.id));
+
+  if (options.channel === "email") {
+    return selected
+      .map((member) => memberEmail(member))
+      .filter((value): value is string => value !== null);
+  }
+
+  return selected
+    .map((member) => memberPhone(member))
+    .filter((value): value is string => value !== null);
+}

--- a/src/lib/messaging/templates.ts
+++ b/src/lib/messaging/templates.ts
@@ -11,6 +11,34 @@ export function resolveSiteUrl(siteUrl?: string): string {
   return value.length > 0 ? value : DEFAULT_SITE_URL;
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+/** Turn plain-text blast body into simple HTML paragraphs; auto-link http(s) URLs. */
+export function plainTextToSimpleHtml(text: string): string {
+  const paragraphs = text
+    .split(/\n+/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+
+  return paragraphs
+    .map((paragraph) => {
+      const escaped = escapeHtml(paragraph);
+      const withLinks = escaped.replace(
+        /(https?:\/\/[^\s<]+)/g,
+        (url) => `<a href="${url}">${url}</a>`,
+      );
+      return `<p>${withLinks}</p>`;
+    })
+    .join("");
+}
+
 export function siteLinkEmailContent(siteUrl?: string): {
   subject: string;
   text: string;
@@ -22,10 +50,7 @@ export function siteLinkEmailContent(siteUrl?: string): {
     `You're invited to the McPeak family directory: ${url}`,
     "Sign in, then complete the reunion survey if prompted.",
   ].join("\n");
-  const html = [
-    `<p>You're invited to the McPeak family directory: <a href="${url}">${url}</a></p>`,
-    "<p>Sign in, then complete the reunion survey if prompted.</p>",
-  ].join("");
+  const html = plainTextToSimpleHtml(text);
 
   return { subject, text, html };
 }

--- a/src/lib/queries/family-api.ts
+++ b/src/lib/queries/family-api.ts
@@ -136,7 +136,12 @@ export interface NotifyBlastResult {
 }
 
 export async function notifyEmailBlast(
-  options: { dryRun?: boolean } = {},
+  options: {
+    dryRun?: boolean;
+    memberIds?: string[];
+    subject?: string;
+    text?: string;
+  } = {},
 ): Promise<NotifyBlastResult> {
   return requestJson<NotifyBlastResult>("/api/notify/email", {
     method: "POST",
@@ -148,7 +153,7 @@ export async function notifyEmailBlast(
 }
 
 export async function notifySmsBlast(
-  options: { dryRun?: boolean } = {},
+  options: { dryRun?: boolean; memberIds?: string[]; text?: string } = {},
 ): Promise<NotifyBlastResult> {
   return requestJson<NotifyBlastResult>("/api/notify/sms", {
     method: "POST",


### PR DESCRIPTION
## Summary
- Lets signed-in users choose email/text recipients from members on file (multi-select + Select all) instead of always sending to everyone.
- Makes the subject and message body editable so prod smoke tests and custom outreach do not need temporary code changes.

## Changes
- Notify dialog: per-channel recipient pickers, editable subject (email) and body (email + text)
- APIs: optional `memberIds`, `subject`, and `text` on `/api/notify/email` and `/api/notify/sms` (contacts still resolved server-side)
- Defaults remain the site-link templates; email HTML is derived from the plain-text body
- UI copy updated for editable sends (Send email / Send text; menu: Email or text)
- Docs and tests updated for the new request body and UI behavior

## Test plan
- [ ] Open **More → Email or text**; confirm subject/body default to the template and all eligible recipients are selected
- [ ] Clear email recipients, select one member, send email and confirm only that address is targeted
- [ ] Clear text recipients, select one member, send text (with SMS enabled) and confirm only that number is targeted
- [ ] Edit subject/body and confirm the sent content matches
- [ ] Confirm dialog says “Send this message to N selected recipient(s)…” (not “site link” / “blast”)
- [ ] Leave subject empty and confirm email send stays disabled; leave body empty and confirm both sends stay disabled
- [ ] `npm test` for notify/messaging/dialog coverage