### PR TITLE
Pin npm packages to exact latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,25 +8,25 @@
       "name": "family",
       "version": "4.0.0",
       "dependencies": {
-        "@aws-sdk/client-dynamodb": "3.1108.0",
-        "@aws-sdk/client-ses": "^3.1108.0",
-        "@aws-sdk/client-sns": "^3.1108.0",
+        "@aws-sdk/client-dynamodb": "3.1110.0",
+        "@aws-sdk/client-ses": "3.1110.0",
+        "@aws-sdk/client-sns": "3.1110.0",
         "@aws-sdk/credential-provider-cognito-identity": "3.972.67",
-        "@aws-sdk/lib-dynamodb": "3.1108.0",
+        "@aws-sdk/lib-dynamodb": "3.1110.0",
         "@emotion/react": "11.14.0",
         "@emotion/styled": "11.14.1",
         "@mui/icons-material": "9.3.1",
         "@mui/material": "9.3.1",
         "@mui/material-nextjs": "9.3.0",
         "@tanstack/react-query": "5.101.4",
-        "next": "^16.3.0",
+        "next": "16.3.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "zod": "4.4.3"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.8",
-        "@next/bundle-analyzer": "^16.3.0",
+        "@next/bundle-analyzer": "16.3.0",
         "@playwright/test": "1.62.1",
         "@testing-library/jest-dom": "7.0.1",
         "@testing-library/react": "16.3.2",
@@ -35,7 +35,7 @@
         "@types/react-dom": "19.2.4",
         "@vitest/coverage-v8": "4.1.10",
         "jsdom": "30.0.1",
-        "typescript": "^7.0.2",
+        "typescript": "7.0.2",
         "vitest": "4.1.10",
         "yaml": "2.9.0"
       },
@@ -84,9 +84,9 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.1108.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1108.0.tgz",
-      "integrity": "sha512-fJPQJFZeLdjlktT/AxnsBUkDVeZeCB4kuU1UEPOD5/JFr8wCDAVdLKNO6pks/0ALnn7ELLfEJb/YfRoc/a7k6g==",
+      "version": "3.1110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1110.0.tgz",
+      "integrity": "sha512-cMGNFPdZq2Y7oSUeQfCikVZe9BorNP09Qdm0c+zzGtOJQPcyMlMb/uxh7P6QrwrYfc5Q7VA40OBtlYnDsXYt/A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.977.7",
@@ -105,9 +105,9 @@
       }
     },
     "node_modules/@aws-sdk/client-ses": {
-      "version": "3.1108.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.1108.0.tgz",
-      "integrity": "sha512-y3lHmjZ2FtbhKdN8k9gbx1WfpSE1QvihWCOMEbyUrTnESB2r6UOxvkyZfol/dMnwyEaVE9Dcoft2fU2JL4UR9g==",
+      "version": "3.1110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.1110.0.tgz",
+      "integrity": "sha512-gEQT3jdJCgRpCxZ8Rb8A9bf/DzAKhsPkc9gxxgqRrf68/T+sEg4I/xHWJefZys9DdmrdRohw2TSE+zUXM1KrpA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.977.7",
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sns": {
-      "version": "3.1108.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1108.0.tgz",
-      "integrity": "sha512-8JTFg2IQxxsleQ1f+H6IwPdt5ZYp4n5TygcSr4uvB6GYO4CKvM9R2Xp48H7RcHleqGoN4aaCBuq195jbxdMF4Q==",
+      "version": "3.1110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1110.0.tgz",
+      "integrity": "sha512-761wPaf9pQGRjFeH79So3t6LXgtYCad853o4Dd+4Sb9vEYnxjwlSnI4OMivimCAv4xksT5/IOKwxsT1tHDL8vg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.977.7",
@@ -354,9 +354,9 @@
       }
     },
     "node_modules/@aws-sdk/lib-dynamodb": {
-      "version": "3.1108.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1108.0.tgz",
-      "integrity": "sha512-MV5JMY4Etst7YiqOp4Mg3z0KLVlwIUAZ5amiazqOEnlWE3Pvja7kWOiQlJ5Qdwid6bygSPWEJp5GCfxbi7cInA==",
+      "version": "3.1110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1110.0.tgz",
+      "integrity": "sha512-g8rWHa4ED8Dxz2iMNRfh3ZeCX1d6pcmY2Geaizmw/rC4Fw1meMZ8jYIFd0BbCzYzOGKimpZ2eKvYRU7a5b1K3A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.977.7",
@@ -369,7 +369,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.1108.0"
+        "@aws-sdk/client-dynamodb": "^3.1110.0"
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {

--- a/package.json
+++ b/package.json
@@ -42,25 +42,25 @@
   },
   "homepage": "https://github.com/jmcpeak/family#readme",
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "3.1108.0",
-    "@aws-sdk/client-ses": "^3.1108.0",
-    "@aws-sdk/client-sns": "^3.1108.0",
+    "@aws-sdk/client-dynamodb": "3.1110.0",
+    "@aws-sdk/client-ses": "3.1110.0",
+    "@aws-sdk/client-sns": "3.1110.0",
     "@aws-sdk/credential-provider-cognito-identity": "3.972.67",
-    "@aws-sdk/lib-dynamodb": "3.1108.0",
+    "@aws-sdk/lib-dynamodb": "3.1110.0",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
     "@mui/icons-material": "9.3.1",
     "@mui/material": "9.3.1",
     "@mui/material-nextjs": "9.3.0",
     "@tanstack/react-query": "5.101.4",
-    "next": "^16.3.0",
+    "next": "16.3.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "zod": "4.4.3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.8",
-    "@next/bundle-analyzer": "^16.3.0",
+    "@next/bundle-analyzer": "16.3.0",
     "@playwright/test": "1.62.1",
     "@testing-library/jest-dom": "7.0.1",
     "@testing-library/react": "16.3.2",
@@ -69,7 +69,7 @@
     "@types/react-dom": "19.2.4",
     "@vitest/coverage-v8": "4.1.10",
     "jsdom": "30.0.1",
-    "typescript": "^7.0.2",
+    "typescript": "7.0.2",
     "vitest": "4.1.10",
     "yaml": "2.9.0"
   },
@@ -77,7 +77,7 @@
     "@mui/material-nextjs": {
       "next": "$next"
     },
-    "postcss": "^8.5.10"
+    "postcss": "8.5.26"
   },
   "allowScripts": {
     "fsevents": true,


### PR DESCRIPTION
## Summary
- Pin all direct npm dependencies to exact versions (no `^`) so installs stay reproducible.
- Bump AWS SDK DynamoDB/SES/SNS/lib-dynamodb to `3.1110.0` and pin `postcss` override to `8.5.26`.

## Changes
- `package.json` / `package-lock.json`: exact pins for Next, AWS SDK, TypeScript, bundle analyzer, and the PostCSS override.

## Test plan
- [ ] `npm ci` succeeds
- [ ] `npm outdated` reports no outdated direct deps
- [ ] `npm run validate` passes


Made with [Cursor](https://cursor.com)