### PR TITLE
Add SMS consent pages and restrict survey auto-open to home

### DIFF
--- a/src/app/sms-privacy/page.test.tsx
+++ b/src/app/sms-privacy/page.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import SmsPrivacyPage from "./page";
+
+describe("SMS privacy page", () => {
+  it("explains how phone numbers are used and how to opt out", () => {
+    render(<SmsPrivacyPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: "McPeak Family Directory SMS privacy",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/do not sell phone numbers/i)).toBeInTheDocument();
+    expect(screen.getByText(/replying STOP/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/sms-privacy/page.tsx
+++ b/src/app/sms-privacy/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { SmsLegalPage } from "@/components/sms-legal-page";
+import {
+  SMS_PRIVACY_PARAGRAPHS,
+  SMS_PROGRAM_NAME,
+} from "@/lib/messaging/sms-program";
+
+export const metadata: Metadata = {
+  title: `SMS privacy · ${SMS_PROGRAM_NAME}`,
+};
+
+export default function SmsPrivacyPage(): React.JSX.Element {
+  return (
+    <SmsLegalPage
+      title={`${SMS_PROGRAM_NAME} SMS privacy`}
+      paragraphs={SMS_PRIVACY_PARAGRAPHS}
+    />
+  );
+}

--- a/src/app/sms-terms/page.test.tsx
+++ b/src/app/sms-terms/page.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import SmsTermsPage from "./page";
+
+describe("SMS terms page", () => {
+  it("is a public SMS program disclosure with STOP language", () => {
+    render(<SmsTermsPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: "McPeak Family Directory SMS terms",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Reply STOP to opt out/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Back to the family directory" }),
+    ).toHaveAttribute("href", "/");
+  });
+});

--- a/src/app/sms-terms/page.tsx
+++ b/src/app/sms-terms/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { SmsLegalPage } from "@/components/sms-legal-page";
+import {
+  SMS_PROGRAM_NAME,
+  SMS_TERMS_PARAGRAPHS,
+} from "@/lib/messaging/sms-program";
+
+export const metadata: Metadata = {
+  title: `SMS terms · ${SMS_PROGRAM_NAME}`,
+};
+
+export default function SmsTermsPage(): React.JSX.Element {
+  return (
+    <SmsLegalPage
+      title={`${SMS_PROGRAM_NAME} SMS terms`}
+      paragraphs={SMS_TERMS_PARAGRAPHS}
+    />
+  );
+}

--- a/src/components/family/editor-fields.tsx
+++ b/src/components/family/editor-fields.tsx
@@ -10,7 +10,7 @@ interface FieldInputProps {
   label: string;
   value?: string | number;
   type?: string;
-  helperText?: string;
+  helperText?: React.ReactNode;
   onChange: (value: string) => void;
 }
 

--- a/src/components/family/sms-consent-notice.tsx
+++ b/src/components/family/sms-consent-notice.tsx
@@ -1,0 +1,22 @@
+import Link from "@mui/material/Link";
+import NextLink from "next/link";
+import {
+  SMS_CONSENT_SUMMARY,
+  SMS_PRIVACY_PATH,
+  SMS_TERMS_PATH,
+} from "@/lib/messaging/sms-program";
+
+export function SmsConsentNotice(): React.JSX.Element {
+  return (
+    <>
+      {SMS_CONSENT_SUMMARY}{" "}
+      <Link component={NextLink} href={SMS_TERMS_PATH}>
+        SMS terms
+      </Link>
+      {" · "}
+      <Link component={NextLink} href={SMS_PRIVACY_PATH}>
+        SMS privacy
+      </Link>
+    </>
+  );
+}

--- a/src/components/family/tabs/address-tab.test.tsx
+++ b/src/components/family/tabs/address-tab.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  SMS_CONSENT_SUMMARY,
+  SMS_PRIVACY_PATH,
+  SMS_TERMS_PATH,
+} from "@/lib/messaging/sms-program";
+import type { FamilyMemberRecord } from "@/lib/types";
+import { AddressTab } from "./address-tab";
+
+const MEMBER: FamilyMemberRecord = {
+  id: "1",
+  firstName: "Ada",
+  lastName: "Lovelace",
+  phone: "555-0123",
+};
+
+describe("AddressTab", () => {
+  it("wires phone changes to updateField", () => {
+    const updateField = vi.fn();
+    render(<AddressTab selectedUser={MEMBER} updateField={updateField} />);
+
+    fireEvent.change(screen.getByLabelText("Phone"), {
+      target: { value: "555-9999" },
+    });
+    expect(updateField).toHaveBeenCalledWith("phone", "555-9999");
+  });
+
+  it("shows SMS consent, STOP language, and public terms links as Phone helper text", () => {
+    render(<AddressTab selectedUser={MEMBER} updateField={vi.fn()} />);
+
+    expect(screen.getByLabelText("Phone")).toHaveAccessibleDescription(
+      expect.stringContaining(SMS_CONSENT_SUMMARY),
+    );
+    expect(screen.getByRole("link", { name: "SMS terms" })).toHaveAttribute(
+      "href",
+      SMS_TERMS_PATH,
+    );
+    expect(screen.getByRole("link", { name: "SMS privacy" })).toHaveAttribute(
+      "href",
+      SMS_PRIVACY_PATH,
+    );
+  });
+});

--- a/src/components/family/tabs/address-tab.tsx
+++ b/src/components/family/tabs/address-tab.tsx
@@ -6,6 +6,7 @@ import { STATE_OPTIONS } from "@/lib/constants";
 import { getGoogleMapsUrl, hasValidAddress } from "@/lib/member-utils";
 import type { FamilyMemberRecord } from "@/lib/types";
 import { FieldInput, FieldSelect, TabGrid } from "../editor-fields";
+import { SmsConsentNotice } from "../sms-consent-notice";
 
 interface AddressTabProps {
   selectedUser: FamilyMemberRecord;
@@ -24,12 +25,15 @@ export function AddressTab({
         value={String(selectedUser.email ?? "")}
         onChange={(value) => updateField("email", value)}
       />
-      <FieldInput
-        label="Phone"
-        type="tel"
-        value={String(selectedUser.phone ?? "")}
-        onChange={(value) => updateField("phone", value)}
-      />
+      <Box sx={{ gridColumn: "1 / -1" }}>
+        <FieldInput
+          label="Phone"
+          type="tel"
+          value={String(selectedUser.phone ?? "")}
+          onChange={(value) => updateField("phone", value)}
+          helperText={<SmsConsentNotice />}
+        />
+      </Box>
       <FieldInput
         label="Address"
         value={String(selectedUser.address ?? "")}

--- a/src/components/sms-legal-page.tsx
+++ b/src/components/sms-legal-page.tsx
@@ -1,0 +1,45 @@
+import Box from "@mui/material/Box";
+import Link from "@mui/material/Link";
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
+interface SmsLegalPageProps {
+  title: string;
+  paragraphs: readonly string[];
+}
+
+export function SmsLegalPage({
+  title,
+  paragraphs,
+}: SmsLegalPageProps): React.JSX.Element {
+  return (
+    <Box
+      sx={{
+        minHeight: "100dvh",
+        display: "grid",
+        placeItems: "center",
+        p: 2,
+      }}
+    >
+      <Paper
+        elevation={3}
+        sx={{ p: { xs: 3, sm: 4 }, width: "min(720px, 100%)" }}
+      >
+        <Typography variant="h4" sx={{ mb: 2 }}>
+          {title}
+        </Typography>
+        <Stack spacing={2}>
+          {paragraphs.map((paragraph) => (
+            <Typography key={paragraph} color="text.secondary">
+              {paragraph}
+            </Typography>
+          ))}
+        </Stack>
+        <Typography sx={{ mt: 3 }}>
+          <Link href="/">Back to the family directory</Link>
+        </Typography>
+      </Paper>
+    </Box>
+  );
+}

--- a/src/hooks/use-survey-lifecycle.test.tsx
+++ b/src/hooks/use-survey-lifecycle.test.tsx
@@ -121,6 +121,29 @@ describe("useSurveyLifecycle", () => {
     });
   });
 
+  it("does not auto-open when the Member is not on the default route", async () => {
+    mockPathname = "/user-abc123";
+    const queryClient = createTestClient();
+    queryClient.setQueryData(familyKeys.surveys(), createSurveysResponse());
+
+    renderHook(
+      () =>
+        useSurveyLifecycle({
+          authenticated: true,
+          directoryReady: true,
+          onError: vi.fn(),
+          onClearError: vi.fn(),
+        }),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
   it("does not auto-open when Survey Lifecycle dismiss is set", async () => {
     dismissSurveyAutoOpen("2027-reunion-interest");
     const queryClient = createTestClient();

--- a/src/hooks/use-survey-lifecycle.tsx
+++ b/src/hooks/use-survey-lifecycle.tsx
@@ -156,6 +156,7 @@ export function useSurveyLifecycle({
     }
 
     if (
+      pathname !== "/" ||
       routeSurveySlug ||
       routeSurveyResultsSlug ||
       surveysQuery.isPending ||
@@ -184,6 +185,7 @@ export function useSurveyLifecycle({
     activeSurveys,
     authenticated,
     openSurvey,
+    pathname,
     routeSurveyResultsSlug,
     routeSurveySlug,
     surveysQuery.isPending,

--- a/src/lib/messaging/blast.test.ts
+++ b/src/lib/messaging/blast.test.ts
@@ -31,6 +31,7 @@ describe("site link templates", () => {
   it("builds a short SMS body", () => {
     const text = siteLinkSmsContent("https://mcpeakfamily.org/");
     expect(text).toContain("https://mcpeakfamily.org");
+    expect(text).toContain("Reply STOP to opt out, HELP for help.");
     expect(text.length).toBeLessThanOrEqual(160);
   });
 });

--- a/src/lib/messaging/sms-program.test.ts
+++ b/src/lib/messaging/sms-program.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  SMS_CONSENT_SUMMARY,
+  SMS_OPT_OUT_INSTRUCTIONS,
+  SMS_PRIVACY_PARAGRAPHS,
+  SMS_PRIVACY_PATH,
+  SMS_PROGRAM_NAME,
+  SMS_TERMS_PARAGRAPHS,
+  SMS_TERMS_PATH,
+} from "./sms-program";
+
+describe("SMS program copy", () => {
+  it("names the program and includes carrier-required consent language", () => {
+    expect(SMS_PROGRAM_NAME).toBe("McPeak Family Directory");
+    expect(SMS_CONSENT_SUMMARY).toContain(SMS_PROGRAM_NAME);
+    expect(SMS_CONSENT_SUMMARY).toContain("a few messages per year");
+    expect(SMS_CONSENT_SUMMARY).toContain("Msg & data rates may apply");
+    expect(SMS_CONSENT_SUMMARY).toContain(SMS_OPT_OUT_INSTRUCTIONS);
+  });
+
+  it("exposes public terms and privacy paths", () => {
+    expect(SMS_TERMS_PATH).toBe("/sms-terms");
+    expect(SMS_PRIVACY_PATH).toBe("/sms-privacy");
+    expect(SMS_TERMS_PARAGRAPHS.join(" ")).toContain("STOP");
+    expect(SMS_PRIVACY_PARAGRAPHS.join(" ")).toContain("STOP");
+  });
+});

--- a/src/lib/messaging/sms-program.ts
+++ b/src/lib/messaging/sms-program.ts
@@ -1,0 +1,21 @@
+export const SMS_PROGRAM_NAME = "McPeak Family Directory";
+export const SMS_TERMS_PATH = "/sms-terms";
+export const SMS_PRIVACY_PATH = "/sms-privacy";
+export const SMS_OPT_OUT_INSTRUCTIONS = "Reply STOP to opt out, HELP for help.";
+export const SMS_FREQUENCY_DISCLOSURE = "a few messages per year";
+export const SMS_CONSENT_SUMMARY = `By adding a phone number, you agree that the ${SMS_PROGRAM_NAME} may send occasional informational texts (${SMS_FREQUENCY_DISCLOSURE}) about the family site and reunion. Msg & data rates may apply. ${SMS_OPT_OUT_INSTRUCTIONS}`;
+
+export const SMS_TERMS_PARAGRAPHS = [
+  `${SMS_PROGRAM_NAME} (https://mcpeakfamily.org) sends infrequent informational text messages to phone numbers that family members add to their own directory profiles.`,
+  `Messages typically include a link to the family site and a short reminder to update contact information or complete a reunion survey. We do not send advertising or marketing texts.`,
+  `Message frequency is ${SMS_FREQUENCY_DISCLOSURE}, usually around reunion planning. Message and data rates may apply.`,
+  `By adding or keeping a phone number on a member profile, you consent to receive these texts. ${SMS_OPT_OUT_INSTRUCTIONS} After you opt out we will not text that number unless a family member adds it again.`,
+  `For help, reply HELP to a program text or contact the family member who maintains the directory.`,
+] as const;
+
+export const SMS_PRIVACY_PARAGRAPHS = [
+  `${SMS_PROGRAM_NAME} stores phone numbers on member profiles so signed-in family members can send the informational texts described in the SMS terms.`,
+  "Phone numbers are used only to deliver those texts through our SMS provider. We do not sell phone numbers or use them for public marketing lists.",
+  "You can remove a number by editing or clearing the Phone field on the member profile, or by replying STOP to a program text.",
+  `See the SMS terms (${SMS_TERMS_PATH}) for consent, frequency, and opt-out details.`,
+] as const;

--- a/src/lib/messaging/templates.ts
+++ b/src/lib/messaging/templates.ts
@@ -57,5 +57,5 @@ export function siteLinkEmailContent(siteUrl?: string): {
 
 export function siteLinkSmsContent(siteUrl?: string): string {
   const url = resolveSiteUrl(siteUrl);
-  return `McPeak family site: ${url} — sign in to update info / reunion survey.`;
+  return `McPeak family site: ${url} — sign in to update info / reunion survey. Reply STOP to opt out, HELP for help.`;
 }


### PR DESCRIPTION
## Summary
- Publish SMS terms and privacy pages plus in-form consent so carrier review can verify opt-in, frequency, and STOP/HELP language.
- Keep the reunion interest survey from auto-opening except on `/`, so member pages and the new legal pages are not interrupted.

## Changes
- Add public `/sms-terms` and `/sms-privacy` pages with program copy, and show consent helper text next to the Phone field.
- Include STOP/HELP language on outbound site-link SMS.
- Auto-open active surveys only when the Member is on the default route.

## Test plan
- [ ] Sign in on `/` with an incomplete active survey and confirm the survey dialog still auto-opens.
- [ ] Open a member profile (not `/`) with an incomplete active survey and confirm the dialog does not auto-open; Surveys menu still opens it.
- [ ] On Address, confirm Phone helper text includes consent, STOP/HELP, and links to `/sms-terms` and `/sms-privacy`.
- [ ] Load `/sms-terms` and `/sms-privacy` signed out and confirm the pages render with a link back to `/`.


Made with [Cursor](https://cursor.com)